### PR TITLE
Fix empty cart error.

### DIFF
--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -1,7 +1,7 @@
 import { getLocalStorage } from "./utils.mjs";
 
 function renderCartContents() {
-  const cartItems = getLocalStorage("so-cart");
+  const cartItems = getLocalStorage("so-cart") || [];
   const htmlItems = cartItems.map((item) => cartItemTemplate(item));
   document.querySelector(".product-list").innerHTML = htmlItems.join("");
 }


### PR DESCRIPTION
Modified cart.js line 4, so if a null is returned from localStorage, the cartItems variable is set to an empty array.